### PR TITLE
implement multi child tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 downloads/
 eggs/
 .eggs/
+.idea/
 lib/
 lib64/
 parts/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-.idea/
 lib/
 lib64/
 parts/

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -2505,6 +2505,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TripleTree:\n",
+    "    def __init__(self, value, left=None, right=None, mid=None):\n",
+    "        self.value = value\n",
+    "        self.left = left\n",
+    "        self.right = right\n",
+    "        self.mid = mid\n",
+    "        \n",
+    "root = TripleTree('parrt',\n",
+    "            TripleTree('mary',[1], [2], [3])) \n",
+    "\n",
+    "treeviz(root, childfields=('left', 'right', 'mid'), show_all_children=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 24,
    "metadata": {},
    "outputs": [
@@ -3972,7 +3991,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.0"
   },
   "toc": {
    "nav_menu": {

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -2524,6 +2524,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MultiTree:\n",
+    "    def __init__(self, value, **children):\n",
+    "        self.value = value\n",
+    "        self.children = children\n",
+    "\n",
+    "root = MultiTree('parrt',\n",
+    "                left = MultiTree('mary', left=[1], right=[2])\n",
+    "                )\n",
+    "\n",
+    "treeplusviz(root, childrenfield=\"children\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 24,
    "metadata": {},
    "outputs": [

--- a/lolviz.py
+++ b/lolviz.py
@@ -130,11 +130,19 @@ def treeviz(root, childfields=('left', 'right'), show_all_children=True):
     s += "}\n"
     return graphviz.Source(s)
 
+
 def treeplusviz(root, childrenfield="children"):
     """
     Display a top-down visualization of a tree just like function treeviz()
     The only difference is that it support more than binary tree.
-    It support a specified field(default "children") which contains all the children to visualize 
+    you can use a specified dictionary(default field "children" of Tree Object) to save all the children
+    e.g.
+    class Tree:
+        def __init__(self, value, **children):
+            self.value = value
+            self.children = children
+    root = Tree("mary", left=1, right=2)
+    treeplusviz(root, childrenfield="children")
     """
     if root is None:
         return
@@ -172,7 +180,7 @@ def treeplusviz(root, childrenfield="children"):
         else:
             s += obj_node(p)
 
-    s += obj_edges(reachable, neglect_fields=[q for (p, q) in children_reachable.values()])
+    s += obj_edges(reachable, neglect_nodes=[q for (p, q) in children_reachable.values()])
     s += children_edges(children_reachable.values())
     s += "}\n"
     return graphviz.Source(s)
@@ -222,7 +230,7 @@ def ndarrayviz(data):
 
 
 def callviz(frame=None, varnames=None):
-    """z
+    """
     Visualize one call stack frame. If frame is None, viz
     caller of callviz()'s frame. Restrict to varnames if
     not None.
@@ -448,14 +456,14 @@ def obj_node(p, varnames=None):
     return s
 
 
-def obj_edges(nodes, varnames=None, neglect_fields=()):
+def obj_edges(nodes, varnames=None, neglect_nodes=()):
     """
-    create all possible edges reachable from `nodes`, neglect nodes in `neglect_fields`
+    create all possible edges reachable from `nodes`, neglect edges related to nodes in `neglect_nodes`
     """
     s = ""
     es = edges(nodes, varnames)
     for (p, label, q) in es:
-        if q in neglect_fields or p in neglect_fields:
+        if q in neglect_nodes or p in neglect_nodes:
             pass
         elif type(p) != types.FrameType and type(p) != dict and type(p) != tuple and hasattr(p,"__iter__") and not isatomlist(p):  # edges start at right edge not center for vertical lists
             s += 'node%d:%s -> node%d:w [arrowtail=dot, penwidth="0.5", color="#444443", arrowsize=.4, weight=100]\n' % (id(p), label, id(q))


### PR DESCRIPTION
Hi, I was looking for a package to visualize Tree Search Algorithm Recently and I found this repository and really liked it. But for tree visualization, the `treeviz` function can only support binary tree with child name `left` and `right`.

So I made some modification  to support multi children and specifying child name. I add 2 new parameters for `treeviz()`, `childfields` and `show_all_children`. The variable name in childfields will be recognized as child node. And if  `show_all_children=False`, it will only visualize the child names exist, else it will show all the names in `childfieds`. 

I know you may be busy and this repository hasn't been updated for a long time. You can check these modification anytime free. I am so glad to receive any suggestions from you.
